### PR TITLE
Configure nginx allow large http request size

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -30,6 +30,7 @@ upstream airflow {
 }
 server {
   listen 80;
+  client_max_body_size 100M;
 
   location ^~ /ng2-amrs {
     rewrite ^/ng2-amrs/(.*) /$1 break;


### PR DESCRIPTION
- Fix the error "413 – Request Entity Too Large” indicates that web server configured to restrict large file size"